### PR TITLE
setChainId now returns chainId if unset.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,8 +55,6 @@ export default class Cosmos {
   async setChainId (chainId = this.chainId) {
     if (!chainId) {
       const { block_meta: { header: { chain_id: chainId } } } = await this.get.block('latest')
-      this.chainId = chainId
-      return
     }
     this.chainId = chainId
 


### PR DESCRIPTION
Fixes a bug where chainId is left undefined if not already set.