### PR TITLE
increase sequence as an integer instead of concatenating it

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -86,7 +86,7 @@ export default class Cosmos {
       hash,
       included
     } = await send({ gas, gasPrices, memo }, messages, signer, this.url, chainId, accountNumber, sequence)
-    this.accounts[senderAddress].sequence += 1
+    this.accounts[senderAddress].sequence = (parseInt(this.accounts[senderAddress].sequence) + 1).toString();
 
     return {
       hash,


### PR DESCRIPTION
We are hitting a weird bug when sending transactions. Instead of incrementing the sequence, it concatenates it because `this.accounts[senderAddress].sequence` is a string. When logging `sequence` on line 90, it goes from `'0'` -> `'01'` -> `'11'` etc. Notice that the third time `'11'` should be '0111' if the problem were that it always concatenates. So for some reason the sequence gets reset to `'1'`, yielding `'11'`. We don't fully understand why this is, but for us it reproducibly blows up on the tenth transaction, when the library tries to send sequence `'91'` to the cosmos node that expects `'10'`. Maybe you guys could take a look at it and try to reproduce this behaviour? Something feels fishy about this workaround. Thanks! 