### PR TITLE
Set content-type header as json when sending json payload

### DIFF
--- a/src/send.js
+++ b/src/send.js
@@ -9,7 +9,12 @@ export default async function send ({ gas, gasPrices = DEFAULT_GAS_PRICE, memo =
 
   // broadcast transaction with signatures included
   const body = createBroadcastBody(signedTx, `sync`)
-  const res = await fetch(`${cosmosRESTURL}/txs`, { method: `POST`, body })
+  const res = await fetch(`${cosmosRESTURL}/txs`, {
+    method: `POST`,
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body })
     .then(res => res.json())
     .then(assertOk)
 

--- a/src/simulate.js
+++ b/src/simulate.js
@@ -26,7 +26,13 @@ export default async function simulate (
 
   const tx = createRESTPOSTObject(senderAddress, chainId, { sequence, accountNumber, memo }, msg)
 
-  const { gas_estimate: gasEstimate } = await fetch(url, { method: `POST`, body: JSON.stringify(tx) }).then(res => res.json())
+  const { gas_estimate: gasEstimate } = await fetch(url, {
+    method: `POST`,
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(tx)
+  }).then(res => res.json())
   return Math.round(gasEstimate * GAS_ADJUSTMENT)
 }
 


### PR DESCRIPTION
Currently the `fetch()` `content-type` header is `text/plain`, but the body is actually a JSON.
This is misleading, and body parsers might ignore the payload.