### PR TITLE
Fixing getter unwrapping bug.

### DIFF
--- a/src/getters.js
+++ b/src/getters.js
@@ -28,7 +28,7 @@ export default function Getters (cosmosRESTURL) {
           return response.result
         }
 
-        return response.result
+        return response
       } catch (err) {
         if (--tries === 0) {
           throw err

--- a/src/getters.js
+++ b/src/getters.js
@@ -13,7 +13,7 @@ export default function Getters (cosmosRESTURL) {
         const isTxsPagination = path.startsWith('/txs?')
         if (isTxsPagination) url = url + `&page=${page}&limit=${limit}`
 
-        const response = await fetch(url).then(res => res.json())
+        let response = await fetch(url).then(res => res.json())
 
         // handle txs pagination
         if (isTxsPagination) {

--- a/src/getters.js
+++ b/src/getters.js
@@ -25,7 +25,7 @@ export default function Getters (cosmosRESTURL) {
         // handle height wrappers
         // most responses are wrapped in a construct containing height and the actual result
         if (response.height !== undefined && response.result !== undefined) {
-          return response.result
+          response = response.result;
         }
 
         return response


### PR DESCRIPTION
Currently get requests that do not return with "height-wrappers" are being unwrapped as if they are. This leads to undefined results for many queries. Removing the unwrapping fixes this issue.