### PR TITLE
Adding type and value wrapper for StdTx calls.

### DIFF
--- a/src/send.js
+++ b/src/send.js
@@ -80,13 +80,16 @@ export function createStdTx ({ gas, gasPrices, memo }, messages) {
   const fees = gasPrices.map(({ amount, denom }) => ({ amount: String(Math.round(amount * gas)), denom }))
     .filter(({ amount }) => amount > 0)
   return {
-    msg: Array.isArray(messages) ? messages : [messages],
-    fee: {
-      amount: fees.length > 0 ? fees : null,
-      gas
-    },
-    signatures: null,
-    memo
+    type: 'cosmos-sdk/StdTx',
+    value: {
+      msg: Array.isArray(messages) ? messages : [messages],
+      fee: {
+        amount: fees.length > 0 ? fees : [],
+        gas: '' + gas,
+      },
+      signatures: null,
+      memo
+    }
   }
 }
 
@@ -101,9 +104,8 @@ function createBroadcastBody (signedTx, returnType = `sync`) {
 
 // adds the signature object to the tx
 function createSignedTransactionObject (tx, signature) {
-  return Object.assign({}, tx, {
-    signatures: [signature]
-  })
+  tx.value.signatures = [signature];
+  return tx;
 }
 
 // assert that a transaction was sent successful

--- a/src/signature.js
+++ b/src/signature.js
@@ -11,20 +11,20 @@ type StdSignMsg struct {
 }
 */
 export function createSignMessage (
-  jsonTx,
+  { type: stdTx, value: tx },
   { sequence, accountNumber, chainId }
 ) {
   // sign bytes need amount to be an array
   const fee = {
-    amount: jsonTx.fee.amount || [],
-    gas: jsonTx.fee.gas
+    amount: tx.fee.amount || [],
+    gas: tx.fee.gas
   }
 
   return JSON.stringify(
     removeEmptyProperties({
       fee,
-      memo: jsonTx.memo,
-      msgs: jsonTx.msg, // weird msg vs. msgs
+      memo: tx.memo,
+      msgs: tx.msg, // weird msg vs. msgs
       sequence,
       account_number: accountNumber,
       chain_id: chainId

--- a/test/signature.spec.js
+++ b/test/signature.spec.js
@@ -6,53 +6,59 @@ import {
 
 describe(`Signing`, () => {
   const tx = {
-    msg: [
-      {
-        type: `cosmos-sdk/Send`,
-        value: {
-          inputs: [
-            {
-              address: `cosmos1qperwt9wrnkg5k9e5gzfgjppzpqhyav5j24d66`,
-              coins: [{ denom: `STAKE`, amount: `1` }]
-            }
-          ],
-          outputs: [
-            {
-              address: `cosmos1yeckxz7tapz34kjwnjxvmxzurerquhtrmxmuxt`,
-              coins: [{ denom: `STAKE`, amount: `1` }]
-            }
-          ]
+    type: 'cosmos-sdk/StdTx',
+    value: {
+      msg: [
+        {
+          type: `cosmos-sdk/Send`,
+          value: {
+            inputs: [
+              {
+                address: `cosmos1qperwt9wrnkg5k9e5gzfgjppzpqhyav5j24d66`,
+                coins: [{ denom: `STAKE`, amount: `1` }]
+              }
+            ],
+            outputs: [
+              {
+                address: `cosmos1yeckxz7tapz34kjwnjxvmxzurerquhtrmxmuxt`,
+                coins: [{ denom: `STAKE`, amount: `1` }]
+              }
+            ]
+          }
         }
-      }
-    ],
-    fee: { amount: [{ denom: ``, amount: `0` }], gas: `21906` },
-    signatures: null,
-    memo: ``
+      ],
+      fee: { amount: [{ denom: ``, amount: `0` }], gas: `21906` },
+      signatures: null,
+      memo: ``
+    }
   }
   const txWithNulls = {
-    msg: [
-      {
-        type: `cosmos-sdk/Send`,
-        value: {
-          inputs: [
-            {
-              address: `cosmos1qperwt9wrnkg5k9e5gzfgjppzpqhyav5j24d66`,
-              coins: [{ denom: `STAKE`, amount: `1` }]
-            }
-          ],
-          outputs: [
-            {
-              x: undefined,
-              address: `cosmos1yeckxz7tapz34kjwnjxvmxzurerquhtrmxmuxt`,
-              coins: [{ denom: `STAKE`, amount: `1` }]
-            }
-          ]
+    type: 'cosmos-sdk/StdTx',
+    value: {
+      msg: [
+        {
+          type: `cosmos-sdk/Send`,
+          value: {
+            inputs: [
+              {
+                address: `cosmos1qperwt9wrnkg5k9e5gzfgjppzpqhyav5j24d66`,
+                coins: [{ denom: `STAKE`, amount: `1` }]
+              }
+            ],
+            outputs: [
+              {
+                x: undefined,
+                address: `cosmos1yeckxz7tapz34kjwnjxvmxzurerquhtrmxmuxt`,
+                coins: [{ denom: `STAKE`, amount: `1` }]
+              }
+            ]
+          }
         }
-      }
-    ],
-    fee: { amount: [{ denom: ``, amount: `0` }], gas: `21906` },
-    signatures: null,
-    memo: ``
+      ],
+      fee: { amount: [{ denom: ``, amount: `0` }], gas: `21906` },
+      signatures: null,
+      memo: ``
+    }
   }
 
   it(`createSignature`, () => {


### PR DESCRIPTION
The signature code for StdTx now requires a type/value wrapper. This is unwrapped when actually sending the transaction. Also making sure that all arguments are strings.