### PR TITLE
Use this as global object

### DIFF
--- a/pending/colw_fix-window-undefined
+++ b/pending/colw_fix-window-undefined
@@ -1,0 +1,1 @@
+[Fixed] [#23](https://github.com/cosmos/lunie/pull/23) Fix 'window is not defined' bug in node environment @colw

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,7 @@ const config = {
     library: 'cosmos-js',
     libraryTarget: 'umd',
     umdNamedDefine: true,
+    globalObject: "this"
   },
   module: {
     rules: [


### PR DESCRIPTION
Fix `window is not defined` bug

Red: https://medium.com/@JakeXiao/window-is-undefined-in-umd-library-output-for-webpack4-858af1b881df